### PR TITLE
fix: revert `extensionId` to match declared command IDs

### DIFF
--- a/src/commonActivate.ts
+++ b/src/commonActivate.ts
@@ -10,7 +10,7 @@ import { AUTHENTICATION_PROVIDER, ServerManagerAuthenticationProvider } from "./
 import { logout, serverSessions } from "./makeRESTRequest";
 import { NamespaceTreeItem, ProjectTreeItem, ServerManagerView, ServerTreeItem, SMTreeItem, WebAppTreeItem } from "./ui/serverManagerView";
 
-export const extensionId = "consistem-sistemas.servermanager";
+export const extensionId = "intersystems-community.servermanager";
 export const OBJECTSCRIPT_EXTENSIONID = "consistem-sistemas.vscode-objectscript";
 
 export let globalState: vscode.Memento;


### PR DESCRIPTION
Reverts the internal `extensionId` constant back to "intersystems-community.servermanager". This fixes the "command not found" error because the commands declared in package.json use this ID as a prefix. The `publisher` in "package.json remains "consistem-sistemas" to prevent Marketplace overwrites.